### PR TITLE
Automated docker build for nomadnet daemon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,42 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+    tags: ['*.*.*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-rc-alpine3.14 as build
+
+RUN apk add --no-cache build-base linux-headers libffi-dev cargo
+
+# Create a virtualenv that we'll copy to the published image
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip3 install setuptools-rust pyopenssl cryptography
+
+COPY . /app/
+RUN cd /app/ && python3 setup.py install
+
+# Use multi-stage build, as we don't need rust compilation on the final image
+FROM python:3.11-rc-alpine3.14
+
+LABEL org.opencontainers.image.documentation="https://github.com/jphastings/NomadNet#using-docker--running-a-daemon"
+
+ENV PATH="/opt/venv/bin:$PATH"
+COPY --from=build /opt/venv /opt/venv
+
+VOLUME /root/.reticulum
+VOLUME /root/.nomadnetwork
+
+ENTRYPOINT ["nomadnet"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ You can install Nomad Network on Android using Termux, but there's a few more co
 
 For a native Android application with a graphical user interface, have a look at [Sideband](https://unsigned.io/sideband).
 
+### Using docker / running a daemon
+
+Nomad Network is automatically published as a docker image on Github Packages. Image tags are one of either `master` (for the latest release) or the version number (eg `0.1.7`) for the specified version number (as tagged in this git repo).
+
+
+```sh
+$ docker pull ghcr.io/markqvist/nomadnet:master
+
+# Run nomadnet interactively without installing it (with default config)
+$ docker run -it ghcr.io/markqvist/nomadnet:master
+
+# Run nomadnet as a daemon, using config stored on the host machine in specific
+# directories, and allowing access to specific numbered ports openned by nomadnet
+# on the host machine on the same port numbers.
+$ docker run -d \
+  -v /local/path/nomadnetconfig/:/root/.nomadnetwork/ \
+  -v /local/path/reticulumconfig/:/root/.reticulum/ \
+  -p 37428:37428 \
+  -p 37429:37429 \
+  ghcr.io/markqvist/nomadnet:master
+```
+
 ## Help & Discussion
 
 For help requests, discussion, sharing ideas or anything else related to Nomad Network, please have a look at the [Nomad Network discussions pages](https://github.com/markqvist/Reticulum/discussions/categories/nomad-network).


### PR DESCRIPTION
Uses a Github Action (`.github/workflows/publish-container.yml`) to create a docker container image (from `Dockerfile`) that represents an extremely minimal python installation with a virtualenv holding all requirements necessary to
execute `nomadnet`.

Once nomadnet supports a daemon mode, we can have those commandline options/config file defaults be present within the default image too (though now it has no special default config, so it only works interactively; see the first `docker run` example below.)

New docker images are created on pushes to `master` or pushes to tags matching `*.*.*` (ie. version tags) and are retrievable with those tags. It's a "multistage build", ie. the heavy lifting (of compiling the rust) is done in a throw-away container, nomadnet is installed to a virtualenv, which is the only thing copied over to the published container, to reduce its size (from ~989MB to ~93MB).

The Github action is [free for public repos](https://github.com/features/packages#pricing) ([docs](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages)); you can see the output from one of my [test runs here](https://github.com/jphastings/NomadNet/runs/6188586039?check_suite_focus=true) (expand the "Build and puhs docker image" row for the build output).

Other notable changes:
- I've added a short piece in the `README.md` on how to use Docker (wording amendments welcome!)
- I've added a `.dockerfileignore` (which is a symlink to `.gitignore`) — this ensures no files that wouldn't be in the git repo are accidentally used as part of the build process. I don't think we need to manage the ignore list separately for now, though there are slight differences in their file formats, if your `.gitignore` needs to get complex.
- The action in `.github/workflow/` is [_straight_ out of the github readme](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages). There might be some additions we want to make, but it works great as-is!

Examples (will run once merged; replace `markqvist` with `jphastings` below to test now):
```sh
$ docker pull ghcr.io/markqvist/nomadnet:master

# Print docker labels, to demonstrate the image has been retrieved
$ docker inspect -f '{{json .Config.Labels}}' ghcr.io/markqvist/nomadnet:master | jq
{
  "org.opencontainers.image.created": "2022-04-27T06:01:55.894Z",
  "org.opencontainers.image.description": "Communicate Freely",
  "org.opencontainers.image.licenses": "GPL-3.0",
  "org.opencontainers.image.revision": "59cffc4a9de0f276d2cc87537ff1316aed5f16dd",
  "org.opencontainers.image.source": "https://github.com/markqvist/NomadNet",
  "org.opencontainers.image.title": "NomadNet",
  "org.opencontainers.image.url": "https://github.com/markqvist/NomadNet",
  "org.opencontainers.image.version": "master"
}

# Run nomadnet interactively without installing it (with default config)
$ docker run -it ghcr.io/markqvist/nomadnet:master

# Run nomadnet as a daemon, using config stored on the host machine in specific directories
$ docker run -d -v /local/path/nomadnetconfig/:/root/.nomadnetwork/ -v /local/path/reticulumconfig/:/root/.reticulum/:rw ghcr.io/markqvist/nomadnet:master
```