### PR TITLE
Move --daemon to CMD from ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ COPY --from=build /opt/venv /opt/venv
 VOLUME /root/.reticulum
 VOLUME /root/.nomadnetwork
 
-ENTRYPOINT ["nomadnet", "--daemon"]
+ENTRYPOINT ["nomadnet"]
+CMD ["--daemon"]


### PR DESCRIPTION
I've moved the `--daemon` command from `ENTRYPOINT` to `CMD` to allow users of the dockerfile some flexibility 

The executable and/or arguments in `CMD` can be overridden easily by users of the container, but `ENTRYPOINT` is intended as a "this is always at the start of the command". ([reference](https://docs.docker.com/engine/reference/builder/#cmd))

For example, with the change in this commit:
- `docker run ghcr.io/markqvist/nomadnet:master --help` will output the same as `nomadnet --help`
- `docker run ghcr.io/markqvist/nomadnet:master` will run `nomadnet --daemon`
- `docker run ghcr.io/markqvist/nomadnet:master ""` will run `nomadnet` (if we wanted this to be a little more self-explaining, there could be a `--ui` flag which runs the UI and is default-on, so `docker run ghcr.io/markqvist/nomadnet:master --ui` would work, as well as the default for the command line app that exists today)