### PR TITLE
Possible fix for Directory error

### DIFF
--- a/nomadnet/Directory.py
+++ b/nomadnet/Directory.py
@@ -90,7 +90,10 @@ class Directory:
 
                 entries = {}
                 for e in unpacked_list:
-                        
+
+                    if e[1] == None:
+                        e[1] = "Undefined"
+
                     if len(e) > 3:
                         hosts_node = e[3]
                     else:


### PR DESCRIPTION
Simply checked for a None value on load, then replaces it with the string "Undefined". Should persist between sessions and be replaced if a functional name appears for the node.

~~**I can't replicate the bug, so this is untested**~~

Edit: Fix has now been tested successfully.