### PR TITLE
Made save paths relative, added page/file refresh

### DIFF
--- a/nomadnet/Node.py
+++ b/nomadnet/Node.py
@@ -15,7 +15,11 @@ class Node:
         self.identity = self.app.identity
         self.destination = RNS.Destination(self.identity, RNS.Destination.IN, RNS.Destination.SINGLE, "nomadnetwork", "node")
         self.last_announce = time.time()
+        self.last_file_refresh = time.time()
+        self.last_page_refresh = time.time()
         self.announce_interval = self.app.node_announce_interval
+        self.page_refresh_interval = self.app.page_refresh_interval
+        self.file_refresh_interval = self.app.file_refresh_interval
         self.job_interval = Node.JOB_INTERVAL
         self.should_run_jobs = True
         self.app_data = None
@@ -222,6 +226,14 @@ class Node:
             
             if now > self.last_announce + self.announce_interval*60:
                 self.announce()
+                
+            if self.page_refresh_interval > 0:
+                if now > self.last_page_refresh + self.page_refresh_interval*60:
+                    self.register_pages()
+                    
+            if self.file_refresh_interval > 0:
+                if now > self.last_file_refresh + self.file_refresh_interval*60:
+                    self.register_files()
 
             time.sleep(self.job_interval)
 

--- a/nomadnet/NomadNetworkApp.py
+++ b/nomadnet/NomadNetworkApp.py
@@ -115,10 +115,12 @@ class NomadNetworkApp:
 
         self.downloads_path    = os.path.expanduser("~/Downloads")
 
-        self.firstrun          = False
-        self.should_run_jobs   = True
-        self.job_interval      = 5
-        self.defer_jobs        = 90
+        self.firstrun               = False
+        self.should_run_jobs        = True
+        self.job_interval           = 5
+        self.defer_jobs             = 90
+        self.page_refresh_interval = 0
+        self.file_refresh_interval  = 0
 
         self.peer_announce_at_start  = True
         self.try_propagation_on_fail = True
@@ -827,12 +829,30 @@ class NomadNetworkApp:
                 if value < 1:
                     value = 1
                 self.node_announce_interval = value
-
+                
             if "pages_path" in self.config["node"]:
                 self.pagespath = self.config["node"]["pages_path"]
+                
+            if not "page_refresh_interval" in self.config["node"]:
+                self.page_refresh_interval = 0
+            else:
+                value = self.config["node"].as_int("page_refresh_interval")
+                if value < 0:
+                    value = 0
+                self.page_refresh_interval = value
+                
 
             if "files_path" in self.config["node"]:
                 self.filespath = self.config["node"]["files_path"]
+                
+            if not "file_refresh_interval" in self.config["node"]:
+                self.file_refresh_interval = 0
+            else:
+                value = self.config["node"].as_int("file_refresh_interval")
+                if value < 0:
+                    value = 0
+                self.file_refresh_interval = value
+                
 
             if "prioritise_destinations" in self.config["node"]:
                 self.prioritised_lxmf_destinations = self.config["node"].as_list("prioritise_destinations")

--- a/nomadnet/ui/textui/Browser.py
+++ b/nomadnet/ui/textui/Browser.py
@@ -976,7 +976,10 @@ class Browser:
         try:
             file_name = request_receipt.response[0]
             file_data = request_receipt.response[1]
-            file_destination = self.app.downloads_path+"/"+file_name
+            file_destination_name = file_name.split("/")
+            file_destination_name = file_destination_name[len(file_destination_name)-1]
+            file_destination = self.app.downloads_path+"/"+file_destination_name
+
             
             counter = 0
             while os.path.isfile(file_destination):


### PR DESCRIPTION
A rather graceless way of doing it, but it ensures downstream compatibility with anything else that looks at file_destination.

Presupposes that "/" is always a directory marker. As far as I know this is true, but I have been known to be wrong.