### PR TITLE
Allow newer versions of urwid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setuptools.setup(
     entry_points= {
         'console_scripts': ['nomadnet=nomadnet.nomadnet:main']
     },
-    install_requires=["rns>=0.7.0", "lxmf>=0.3.8", "urwid==2.1.2", "qrcode"],
+    install_requires=["rns>=0.7.0", "lxmf>=0.3.8", "urwid>=2.1.2", "qrcode"],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Last urwid versions are backward-compatible with 2.1.2 (but may produce "DeprecationWarning" on legacy logic)