### PR TITLE
Ban `urwid==2.4.3` as containing UI regression.

### DIFF
--- a/nomadnet/ui/textui/Config.py
+++ b/nomadnet/ui/textui/Config.py
@@ -13,7 +13,7 @@ class ConfigFiller(urwid.WidgetWrap):
     def __init__(self, widget, app):
         self.app = app
         self.filler = urwid.Filler(widget, "top")
-        urwid.WidgetWrap.__init__(self, self.filler)
+        super().__init__(self.filler)
 
 
     def keypress(self, size, key):
@@ -71,7 +71,7 @@ class EditorTerminal(urwid.WidgetWrap):
 
         urwid.connect_signal(self.term, 'closed', quit_term)
 
-        urwid.WidgetWrap.__init__(self, self.term)
+        super().__init__(self.term)
 
 
     def keypress(self, size, key):

--- a/nomadnet/ui/textui/Conversations.py
+++ b/nomadnet/ui/textui/Conversations.py
@@ -788,7 +788,7 @@ class ConversationWidget(urwid.WidgetWrap):
         if source_hash == None:
             self.frame = None
             display_widget = urwid.LineBox(urwid.Filler(urwid.Text("\n  No conversation selected"), "top"))
-            urwid.WidgetWrap.__init__(self, display_widget)
+            super().__init__(display_widget)
         else:
             if source_hash in ConversationsDisplay.cached_conversation_widgets:
                 return ConversationsDisplay.cached_conversation_widgets[source_hash]
@@ -852,7 +852,7 @@ class ConversationWidget(urwid.WidgetWrap):
                     self.frame
                 )
                 
-                urwid.WidgetWrap.__init__(self, self.display_widget)
+                super().__init__(self.display_widget)
 
     def clear_history_dialog(self):
         def dismiss_dialog(sender):
@@ -1141,7 +1141,7 @@ class LXMessageWidget(urwid.WidgetWrap):
             urwid.Text("")
         ])
 
-        urwid.WidgetWrap.__init__(self, display_widget)
+        super().__init__(display_widget)
 
 class SyncProgressBar(urwid.ProgressBar):
     def get_text(self):

--- a/nomadnet/ui/textui/Guide.py
+++ b/nomadnet/ui/textui/Guide.py
@@ -75,7 +75,7 @@ class GuideEntry(urwid.WidgetWrap):
         style = "topic_list_normal"
         focus_style = "list_focus"
         self.display_widget = urwid.AttrMap(widget, style, focus_style)
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def display_topic(self, event, topic):
         markup = TOPICS[topic]
@@ -125,7 +125,7 @@ class TopicList(urwid.WidgetWrap):
             highlight_offFocus="list_off_focus"
         )
 
-        urwid.WidgetWrap.__init__(self, urwid.LineBox(self.ilb, title="Topics"))
+        super().__init__(urwid.LineBox(self.ilb, title="Topics"))
 
 
     def keypress(self, size, key):

--- a/nomadnet/ui/textui/Log.py
+++ b/nomadnet/ui/textui/Log.py
@@ -40,7 +40,7 @@ class LogTerminal(urwid.WidgetWrap):
             escape_sequence="up",
             main_loop=self.app.ui.loop,
         )
-        urwid.WidgetWrap.__init__(self, self.log_term)
+        super().__init__(self.log_term)
 
     def terminate(self):
         self.log_term.terminate()

--- a/nomadnet/ui/textui/MicronParser.py
+++ b/nomadnet/ui/textui/MicronParser.py
@@ -608,7 +608,7 @@ class LinkSpec(urwid.AttrSpec):
         self.link_target = link_target
         self.link_fields = None
 
-        urwid.AttrSpec.__init__(self, orig_spec.foreground, orig_spec.background)
+        super().__init__(orig_spec.foreground, orig_spec.background)
 
 
 class LinkableText(urwid.Text):
@@ -618,7 +618,7 @@ class LinkableText(urwid.Text):
     signals = ["click", "change"]
 
     def __init__(self, text, align=None, cursor_position=0, delegate=None):
-        self.__super.__init__(text, align=align)
+        super().__init__(text, align=align)
         self.delegate = delegate
         self._cursor_position = 0
         self.key_timeout = 3
@@ -729,7 +729,7 @@ class LinkableText(urwid.Text):
 
     def render(self, size, focus=False):
         now = time.time()
-        c = self.__super.render(size, focus)
+        c = super().render(size, focus)
 
         if focus and (self.delegate == None or now < self.delegate.last_keypress+self.key_timeout):
             c = urwid.CompositeCanvas(c)

--- a/nomadnet/ui/textui/Network.py
+++ b/nomadnet/ui/textui/Network.py
@@ -234,7 +234,7 @@ class AnnounceInfo(urwid.WidgetWrap):
 
         self.display_widget = urwid.Filler(pile, valign="top", height="pack")
 
-        urwid.WidgetWrap.__init__(self, urwid.LineBox(self.display_widget, title="Announce Info"))
+        super().__init__(urwid.LineBox(self.display_widget, title="Announce Info"))
 
 
 class AnnounceStreamEntry(urwid.WidgetWrap):
@@ -296,7 +296,7 @@ class AnnounceStreamEntry(urwid.WidgetWrap):
         urwid.connect_signal(widget, "click", self.display_announce, announce)
 
         self.display_widget = urwid.AttrMap(widget, style, focus_style)
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def display_announce(self, event, announce):
       try:
@@ -365,7 +365,7 @@ class AnnounceStream(urwid.WidgetWrap):
         )
 
         self.display_widget = self.ilb
-        urwid.WidgetWrap.__init__(self, urwid.LineBox(self.display_widget, title="Announce Stream"))
+        super().__init__(urwid.LineBox(self.display_widget, title="Announce Stream"))
 
     def keypress(self, size, key):
         if key == "up" and (self.no_content or self.ilb.first_item_is_selected()):
@@ -681,7 +681,7 @@ class KnownNodeInfo(urwid.WidgetWrap):
 
         self.display_widget = urwid.Filler(pile, valign="top", height="pack")
 
-        urwid.WidgetWrap.__init__(self, urwid.LineBox(self.display_widget, title="Node Info"))
+        super().__init__(urwid.LineBox(self.display_widget, title="Node Info"))
 
 
 # Yes, this is weird. There is a bug in Urwid/ILB that causes
@@ -726,7 +726,7 @@ class KnownNodes(urwid.WidgetWrap):
             self.pile = urwid.Pile([urwid.Text(("warning_text", g["info"]+"\n"), align="center"), SelectText(("warning_text", "Currently, no nodes are saved\n\nCtrl+L to view the announce stream\n\n"), align="center")])
             self.display_widget = urwid.Filler(self.pile, valign="top", height="pack")
 
-        urwid.WidgetWrap.__init__(self, urwid.AttrMap(urwid.LineBox(self.display_widget, title="Saved Nodes"), widget_style))
+        super().__init__(urwid.AttrMap(urwid.LineBox(self.display_widget, title="Saved Nodes"), widget_style))
 
     def keypress(self, size, key):
         if key == "up" and (self.no_content or self.ilb.first_item_is_selected()):
@@ -869,7 +869,7 @@ class NodeEntry(urwid.WidgetWrap):
 
         self.display_widget = urwid.AttrMap(widget, style, focus_style)
         self.display_widget.source_hash = source_hash
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
 
 class AnnounceTime(urwid.WidgetWrap):
@@ -880,7 +880,7 @@ class AnnounceTime(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_time()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_time(self):
         self.last_announce_string = "Never"
@@ -912,7 +912,7 @@ class NodeAnnounceTime(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_time()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_time(self):
         self.last_announce_string = "Never"
@@ -943,7 +943,7 @@ class NodeActiveConnections(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_stat()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_stat(self):
         self.stat_string = "None"
@@ -974,7 +974,7 @@ class NodeStorageStats(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_stat()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_stat(self):
         self.stat_string = "None"
@@ -1017,7 +1017,7 @@ class NodeTotalConnections(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_stat()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_stat(self):
         self.stat_string = "None"
@@ -1049,7 +1049,7 @@ class NodeTotalPages(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_stat()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_stat(self):
         self.stat_string = "None"
@@ -1081,7 +1081,7 @@ class NodeTotalFiles(urwid.WidgetWrap):
         self.display_widget = urwid.Text("")
         self.update_stat()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update_stat(self):
         self.stat_string = "None"
@@ -1193,7 +1193,7 @@ class LocalPeer(urwid.WidgetWrap):
             ]
         )
 
-        urwid.WidgetWrap.__init__(self, urwid.LineBox(self.display_widget, title="Local Peer Info"))
+        super().__init__(urwid.LineBox(self.display_widget, title="Local Peer Info"))
 
     def start(self):
         self.t_last_announce.start()
@@ -1369,7 +1369,7 @@ class NodeInfo(urwid.WidgetWrap):
 
         self.display_widget = pile
 
-        urwid.WidgetWrap.__init__(self, urwid.AttrMap(urwid.LineBox(self.display_widget, title="Local Node Info"), widget_style))
+        super().__init__(urwid.AttrMap(urwid.LineBox(self.display_widget, title="Local Node Info"), widget_style))
 
     def start(self):
         if self.app.node != None:
@@ -1392,7 +1392,7 @@ class UpdatingText(urwid.WidgetWrap):
         self.append_text = append_text
         self.update()
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def update(self):
         self.value = self.value_method()
@@ -1434,7 +1434,7 @@ class NetworkStats(urwid.WidgetWrap):
 
         self.display_widget = urwid.LineBox(pile, title="Network Stats")
 
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
     def start(self):
         self.w_heard_peers.start()
@@ -1620,7 +1620,7 @@ class LXMFPeers(urwid.WidgetWrap):
             pl = len(self.peer_list)
         else:
             pl = 0
-        urwid.WidgetWrap.__init__(self, urwid.AttrMap(urwid.LineBox(self.display_widget, title=f"LXMF Propagation Peers ({pl})"), widget_style))
+        super().__init__(urwid.AttrMap(urwid.LineBox(self.display_widget, title=f"LXMF Propagation Peers ({pl})"), widget_style))
 
     def keypress(self, size, key):
         if key == "up" and (self.no_content or self.ilb.first_item_is_selected()):
@@ -1741,7 +1741,7 @@ class LXMFPeerEntry(urwid.WidgetWrap):
         widget = ListEntry(sym+" "+display_str+"\n  "+alive_string+", last heard "+pretty_date(int(peer.last_heard))+"\n  "+str(len(peer.unhandled_messages))+" unhandled LXMs, "+RNS.prettysize(peer.link_establishment_rate/8, "b")+"/s LER")
         self.display_widget = urwid.AttrMap(widget, style, focus_style)
         self.display_widget.destination_hash = destination_hash
-        urwid.WidgetWrap.__init__(self, self.display_widget)
+        super().__init__(self.display_widget)
 
 
 def pretty_date(time=False):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setuptools.setup(
     entry_points= {
         'console_scripts': ['nomadnet=nomadnet.nomadnet:main']
     },
-    install_requires=["rns>=0.7.0", "lxmf>=0.3.9", "urwid==2.4.2", "qrcode"],
+    install_requires=["rns>=0.7.0", "lxmf>=0.3.9", "urwid>=2.4.2,!=2.4.3", "qrcode"],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Fix urwid entities init: use correct `super()`,
hack `__super` is officially deprecated.
Method <Class>.method(self, ...) is only for fallback in corner cases (normally not recommended to use).