### PR TITLE
Add Checkbox and Radio Group fields to Micron 

### DIFF
--- a/nomadnet/examples/various/input_fields.py
+++ b/nomadnet/examples/various/input_fields.py
@@ -31,7 +31,7 @@ The data can be `!`[submitted`:/page/input_fields.mu`username|two]`!.
 
 >> Checkbox Fields
 
-`B444`<?|sign_up|1`>`b Sign me up
+`B444`<?|sign_up|1|*`>`b Sign me up 
 
 >> Radio group
 

--- a/nomadnet/examples/various/input_fields.py
+++ b/nomadnet/examples/various/input_fields.py
@@ -17,6 +17,8 @@ The following section contains a simple set of fields, and a few different links
 
 -=
 
+
+>>>Text Fields
 An input field    : `B444`<username`Entered data>`b
 
 An masked field   : `B444`<!|password`Value of Field>`b
@@ -27,7 +29,24 @@ Two fields        : `B444`<8|one`One>`b `B444`<8|two`Two>`b
 
 The data can be `!`[submitted`:/page/input_fields.mu`username|two]`!.
 
-You can `!`[submit`:/page/input_fields.mu`one|password|small]`! other fields, or just `!`[a single one`:/page/input_fields.mu`username]`!
+>> Checkbox Fields
+
+`B444`<?|sign_up|1`>`b Sign me up
+
+>> Radio group
+
+Select your favorite color:
+
+`B900`<^|color|Red`>`b  Red
+
+`B090`<^|color|Green`>`b Green
+
+`B009`<^|color|Blue`>`b Blue
+
+
+>>> Submitting data
+
+You can `!`[submit`:/page/input_fields.mu`one|password|small|color]`! other fields, or just `!`[a single one`:/page/input_fields.mu`username]`!
 
 Or simply `!`[submit them all`:/page/input_fields.mu`*]`!.
 

--- a/nomadnet/ui/textui/Guide.py
+++ b/nomadnet/ui/textui/Guide.py
@@ -1152,6 +1152,43 @@ A sized input field:  `B444`<16|with_size`>`B333
 A masked input field: `B444`<!|masked_demo`hidden text>`B333
 
 Full control: `B444`<!32|all_options`hidden text>`B333
+`b
+>>> Checkboxes
+
+In addition to text fields, Checkboxes are another way of submitting data. They allow the user to make a single selection or select multiple options. 
+
+`Faaa
+`=
+`<?|field_name|value`>`b Label Text`
+`=
+When the checkbox is checked, it's field will be set to the provided value. If there are multiple checkboxes that share the same field name, the checked values will be concatenated when they are sent to the node by a comma.
+``
+
+`B444`<?|sign_up|1`>`b Sign me up`
+
+>>> Radio groups
+
+Radio groups are another input that lets the user chose from a set of options. Unlike checkboxes, radio buttons with the same field name are mutually exclusive.
+
+Example:
+
+`=
+`B900`<^|color|Red`>`b  Red
+
+`B090`<^|color|Green`>`b Green
+
+`B009`<^|color|Blue`>`b Blue
+`=
+
+will render:
+
+`B900`<^|color|Red`>`b  Red
+
+`B090`<^|color|Green`>`b Green
+
+`B009`<^|color|Blue`>`b Blue
+
+In this example, when the data is submitted, `B444` field_color`b will be set to whichever value from the list was selected.
 
 ``
 

--- a/nomadnet/ui/textui/Guide.py
+++ b/nomadnet/ui/textui/Guide.py
@@ -1166,6 +1166,10 @@ When the checkbox is checked, it's field will be set to the provided value. If t
 
 `B444`<?|sign_up|1`>`b Sign me up`
 
+You can also pre-check both checkboxes and radio groups by appending a |* after the field value.
+
+`B444`<?|checkbox|1|*`>`b Pre-checked checkbox`
+
 >>> Radio groups
 
 Radio groups are another input that lets the user chose from a set of options. Unlike checkboxes, radio buttons with the same field name are mutually exclusive.

--- a/nomadnet/ui/textui/MicronParser.py
+++ b/nomadnet/ui/textui/MicronParser.py
@@ -177,7 +177,8 @@ def parse_line(line, state, url_delegate):
                             fv = o["value"]
                             flabel = o["label"]
                             fs = o["style"]
-                            f = urwid.CheckBox(flabel, state=False)
+                            fprechecked = o.get("prechecked", False)  
+                            f = urwid.CheckBox(flabel, state=fprechecked)
                             f.field_name = fn
                             f.field_value = fv
                             fa = urwid.AttrMap(f, fs)
@@ -187,16 +188,18 @@ def parse_line(line, state, url_delegate):
                             fv = o["value"]
                             flabel = o["label"]
                             fs = o["style"]
-                            if not "radio_groups" in state:
+                            fprechecked = o.get("prechecked", False)  
+                            if "radio_groups" not in state:
                                 state["radio_groups"] = {}
-                            if not fn in state["radio_groups"]:
+                            if fn not in state["radio_groups"]:
                                 state["radio_groups"][fn] = []
                             group = state["radio_groups"][fn]
-                            f = urwid.RadioButton(group, flabel, state=False, user_data=fv)
+                            f = urwid.RadioButton(group, flabel, state=fprechecked, user_data=fv)
                             f.field_name = fn
                             f.field_value = fv
                             fa = urwid.AttrMap(f, fs)
                             widgets.append((urwid.PACK, fa))
+
 
 
 
@@ -501,6 +504,7 @@ def make_output(state, line, url_delegate):
                                 field_name = field_content
                                 field_value = ""
                                 field_data = ""
+                                field_prechecked = False  
 
                                 # check if field_content contains '|'
                                 if '|' in field_content:
@@ -526,10 +530,23 @@ def make_output(state, line, url_delegate):
                                         except ValueError:
                                             pass  # Ignore invalid width
 
+                                    # Check for value and pre-checked flag
                                     if len(f_components) > 2:
                                         field_value = f_components[2]
+                                    else:
+                                        field_value = ""
+                                    if len(f_components) > 3:
+                                        if f_components[3] == '*':
+                                            field_prechecked = True
+
                                 else:
+                                    # No '|', so field_name is field_content
                                     field_name = field_content
+                                    field_type = "field"
+                                    field_masked = False
+                                    field_width = 24
+                                    field_value = ""
+                                    field_prechecked = False
 
                                 # Find the closing '>' character
                                 field_end = line.find('>', backtick_pos)
@@ -546,6 +563,7 @@ def make_output(state, line, url_delegate):
                                             "name": field_name,
                                             "value": field_value if field_value else field_data,
                                             "label": field_data,
+                                            "prechecked": field_prechecked,
                                             "style": make_style(state)
                                         })
                                     else:


### PR DESCRIPTION
This PR adds two new input field types to the Micron markdown format. The two fields use either a `^` (radio) or `?` (checkbox) after the `<` in the  field markup. 

## Checkboxes
Checkboxes allow users to make  a single selection or multiple selections. They are rendered using the Urwid `CheckBox` widget. 

Example:
```
`<?|field_name|value`>`b Label Text`
```
- **`field_name`**: The name of the field. Multiple checkboxes can share the same `field_name`
- **`value`**: The value submitted when the checkbox is checked. If their are multiple checkboxes with the same field name, but different values it will concatenate all checked values with a comma.

## Radio select
Radio selects allow users to choose one option from a list. They are rendered using the Urwid `RadioButton` widget. 

Unlike checkboxes radio buttons with the same field name are mutually exclusive.

Example:
```
`B900`<^|color|Red`>`b  Red

`B090`<^|color|Green`>`b Green

`B009`<^|color|Blue`>`b Blue
```

In this example, when the data is submitted field_color will be set to whichever value from the list was selected.

![Screenshot from 2024-11-25 18-40-18](https://github.com/user-attachments/assets/4eecdd63-9847-4b6e-8a1f-200297a5a47a)

Both checkboxes and radio groups can be pre-checked by appending a `|*` after the field value


Additionally, for LXMF clients like Liam Cottle's MeshChat that are browser-based, these can be mirrored using the native HTML radio select and checkboxes. 