### PR TITLE
Fix serving NomadNet pages from Windows

### DIFF
--- a/nomadnet/Node.py
+++ b/nomadnet/Node.py
@@ -1,4 +1,6 @@
 import os
+import sys
+
 import RNS
 import time
 import threading
@@ -159,7 +161,8 @@ class Node:
         try:
             if request_allowed:
                 RNS.log("Serving page: "+file_path, RNS.LOG_VERBOSE)
-                if os.access(file_path, os.X_OK):
+                is_windows = sys.platform == "win32"
+                if is_windows is False and os.access(file_path, os.X_OK):
                     env_map = {}
                     if "PATH" in os.environ:
                         env_map["PATH"] = os.environ["PATH"]


### PR DESCRIPTION
As discussed in https://github.com/markqvist/Reticulum/discussions/636, it's currently not possible to serve NomadNet pages from a Windows machine.

This is because Windows sets files as executable by default, which means NomadNet tries to execute them when the page is requested. This fails on Windows with the error `not a valid Win32 application`.

To allow serving pages on Windows, this PR just skips trying to execute the file when running on Windows.