### PR TITLE
Fix Scrollable.py

### DIFF
--- a/nomadnet/vendor/Scrollable.py
+++ b/nomadnet/vendor/Scrollable.py
@@ -50,7 +50,7 @@ class Scrollable(urwid.WidgetDecoration):
         self._old_cursor_coords = None
         self._rows_max_cached = 0
         self.force_forward_keypress = force_forward_keypress
-        self.__super.__init__(widget)
+        super().__init__(widget)
 
     def render(self, size, focus=False):
         maxcol, maxrow = size
@@ -340,7 +340,7 @@ class ScrollBar(urwid.WidgetDecoration):
         """
         if BOX not in widget.sizing():
             raise ValueError('Not a box widget: %r' % widget)
-        self.__super.__init__(widget)
+        super().__init__(widget)
         self._thumb_char = thumb_char
         self._trough_char = trough_char
         self.scrollbar_side = side


### PR DESCRIPTION
Python Version: `3.13`
Install Method: pipx

Error: AttributeError: 'Scrollable' object has no attribute '_Scrollable__super'

Fix: b9ac735308f697ff0d98f572fc94c3e8202095cc

After I applied fix the page would render, no further errors.

<details>
<summary><strong>Full Error Logs</strong></summary>

```
25-05-08 18:08:19] [Error]    An unhandled exception occurred, the details of which will be dumped below
[2025-05-08 18:08:19] [Error]    Type  : <class 'AttributeError'>
[2025-05-08 18:08:19] [Error]    Value : 'Scrollable' object has no attribute '_Scrollable__super'
[2025-05-08 18:08:19] [Error]    Trace : 
  File "/home/dev/.local/bin/nomadnet", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/nomadnet.py", line 51, in main
    program_setup(configarg, rnsconfigarg, daemon, console)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/nomadnet.py", line 11, in program_setup
    app = nomadnet.NomadNetworkApp(
        configdir = configdir,
    ...<2 lines>...
        force_console = console,
    )
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/NomadNetworkApp.py", line 402, in __init__
    nomadnet.ui.spawn(self.uimode)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/__init__.py", line 29, in spawn
    return TextUI()
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/TextUI.py", line 211, in __init__
    self.loop.run()
    ~~~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/main_loop.py", line 339, in run
    self._run()
    ~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/main_loop.py", line 441, in _run
    self.event_loop.run()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/select_loop.py", line 182, in run
    self._loop()
    ~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/select_loop.py", line 229, in _loop
    record.data()
    ~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/display/_posix_raw_display.py", line 285, in wrapper
    return self.parse_input(event_loop, callback, self.get_available_raw_input())
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/display/_raw_display_base.py", line 488, in parse_input
    callback(decoded_codes, raw_codes)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/main_loop.py", line 466, in _update
    self.process_input(keys)
    ~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/event_loop/main_loop.py", line 570, in process_input
    if hasattr(self._topmost_widget, "mouse_event") and self._topmost_widget.mouse_event(
                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.screen_size,
        ^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        focus=True,
        ^^^^^^^^^^^
    ):
    ^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Main.py", line 74, in mouse_event
    return super(MainFrame, self).mouse_event(size, event, button, col, row, focus)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/frame.py", line 558, in mouse_event
    return self.body.mouse_event((maxcol, maxrow - htrim - ftrim), event, button, col, row - htrim, focus)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/columns.py", line 1121, in mouse_event
    return w.mouse_event(w_size, event, button, col - x, row, focus)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/pile.py", line 1049, in mouse_event
    return w.mouse_event(w_size, event, button, col, target_row, focus and self.focus == w)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/pile.py", line 1049, in mouse_event
    return w.mouse_event(w_size, event, button, col, target_row, focus and self.focus == w)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/columns.py", line 1121, in mouse_event
    return w.mouse_event(w_size, event, button, col - x, row, focus)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/pile.py", line 1049, in mouse_event
    return w.mouse_event(w_size, event, button, col, target_row, focus and self.focus == w)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/columns.py", line 1121, in mouse_event
    return w.mouse_event(w_size, event, button, col - x, row, focus)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/wimp.py", line 785, in mouse_event
    self._emit("click")
    ~~~~~~~~~~^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/widget/widget.py", line 310, in _emit
    signals.emit_signal(self, name, self, *args)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/signals.py", line 299, in emit
    result |= self._call_callback(callback, user_arg, weak_args, user_args, args)
              ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/urwid/signals.py", line 323, in _call_callback
    return bool(callback(*args))
                ~~~~~~~~^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Network.py", line 1357, in connect_query
    self.parent.browser.retrieve_url(RNS.hexrep(self.app.node.destination.hash, delimit=False))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Browser.py", line 493, in retrieve_url
    self.load_page()
    ~~~~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Browser.py", line 808, in load_page
    self.update_display()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Browser.py", line 378, in update_display
    self.update_page_display()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/ui/textui/Browser.py", line 412, in update_page_display
    self.browser_body = urwid.AttrMap(ScrollBar(Scrollable(pile, force_forward_keypress=True), thumb_char="\u2503", trough_char=" "), "scrollbar")
                                                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/share/pipx/venvs/nomadnet/lib/python3.13/site-packages/nomadnet/vendor/Scrollable.py", line 53, in __init__
    self.__super.__init__(widget)
    ^^^^^^^^^^^^
```

