### PR TITLE
Fix Guide description on authenticating users

### DIFF
--- a/nomadnet/ui/textui/Guide.py
+++ b/nomadnet/ui/textui/Guide.py
@@ -345,7 +345,7 @@ By default, you can find the examples in `!~/.nomadnetwork/examples`!. If you bu
 
 Sometimes, you don't want everyone to be able to view certain pages or execute certain scripts. In such cases, you can use `*authentication`* to control who gets to run certain requests.
 
-To enable authentication for any page, simply add a new file to your pages directory with ".allowed" added to the file-name of the page. If your page is named "secret_page.mu", just add a file named "secret_page.allowed".
+To enable authentication for any page, simply add a new file to your pages directory with ".allowed" added to the file-name of the page. If your page is named "secret_page.mu", just add a file named "secret_page.mu.allowed".
 
 For each user allowed to access the page, add a line to this file, containing the hash of that users primary identity. Users can find their own identity hash in the `![ Network ]`! part of the program, under `!Local Peer Info`!. If you want to allow access for three different users, your file would look like this:
 


### PR DESCRIPTION
`secret_page.mu` would require an allow list file at `secret_page.mu.allowed`, not `secret_page.allowed` from my testing.

Also note: The `.allowed` files *cannot have trailing newlines*; they will not work if they do.
I do not know if this is a bug or intended behavior, but I couldn't get it to work for the longest time because my text editor appends a newline to the end of files on save by default