### PR TITLE
micronparser: Fix a parsing bug

### DIFF
--- a/nomadnet/ui/textui/MicronParser.py
+++ b/nomadnet/ui/textui/MicronParser.py
@@ -148,6 +148,9 @@ def parse_line(line, state, url_delegate):
             elif first_char == "-":
                 if len(line) == 2:
                     divider_char = line[1]
+                    # Control characters don't make sense here and otherwise crash nomadnet
+                    if ord(divider_char) < 32:
+                        divider_char = "\u2500"
                 else:
                     divider_char = "\u2500"
                 if state["depth"] == 0:


### PR DESCRIPTION
This fixes a bug that crashes nomadnet when parsing a micron page with control characters in specific places. A simple micron page to reproduce this is (bytes) `2d 0d 0a`. Reported by @qbit in the Matrix room when discovered in the wild in the `c06e84d31ab49439a7d6a7c064f43f7c` node.

PS. I preferred to use a second `if` for readability, but this can be inverted in the parent `if` too.